### PR TITLE
stringslice: use strings.EqualFold for HasI

### DIFF
--- a/stringslice/has.go
+++ b/stringslice/has.go
@@ -15,7 +15,7 @@ func Has(haystack []string, needle string) bool {
 // HasI returns true if the needle is in the haystack (case-insensitive)
 func HasI(haystack []string, needle string) bool {
 	for _, current := range haystack {
-		if strings.ToLower(current) == strings.ToLower(needle) {
+		if strings.EqualFold(current, needle) {
 			return true
 		}
 	}

--- a/stringslice/has_test.go
+++ b/stringslice/has_test.go
@@ -18,3 +18,18 @@ func TestHasI(t *testing.T) {
 	assert.True(t, HasI([]string{"foo", "baR"}, "bar"))
 	assert.False(t, HasI([]string{"foo", "bar"}, "baz"))
 }
+
+func BenchmarkHasI(b *testing.B) {
+	var heystack = []string{
+		"apple",
+		"orange",
+		"banana",
+		"strawberry",
+		"cherry",
+		"pear",
+		"pineapple",
+	}
+	for i := 0; i < b.N; i++ {
+		HasI(heystack, "cherry")
+	}
+}


### PR DESCRIPTION
Hi.

This PR uses `strings.EqualFold` instead of  `strings.ToLower(current) == strings.ToLower(needle)` in `stringslice.HasI` for case-insensitive comparison. This change make `HasI` almost 3x faster.

```
benchmark            old ns/op     new ns/op     delta
BenchmarkHasI-12     90.0          33.2          -63.11%

benchmark            old allocs     new allocs     delta
BenchmarkHasI-12     0              0              +0.00%

benchmark            old bytes     new bytes     delta
BenchmarkHasI-12     0             0             +0.00%
```